### PR TITLE
Fix clippedBy logic

### DIFF
--- a/rect.py
+++ b/rect.py
@@ -171,11 +171,17 @@ class Rect(object):
         >>> r1.clippedBy(r2)
         True
         '''
-        if self.intersects(other): return True
-        if i.x > self.x: return True
-        if i.y > self.y: return True
-        if i.width < self.width: return True
-        if i.height < self.height: return True
+        i = self.intersect(other)
+        if i is None:
+            return True
+        if i.x > self.x:
+            return True
+        if i.y > self.y:
+            return True
+        if i.width < self.width:
+            return True
+        if i.height < self.height:
+            return True
         return False
 
     def intersect(self, other):


### PR DESCRIPTION
## Summary
- fix variable reference and logic in Rect.clippedBy

## Testing
- `python3 -m py_compile rect.py`
- `python3 -m py_compile main.py tmx.py`
- `python3 - <<'EOF'
from rect import Rect
r1 = Rect(0,0,10,10)
r2 = Rect(1,1,9,9)
print('r2.clippedBy(r1)=', r2.clippedBy(r1))
print('r1.clippedBy(r2)=', r1.clippedBy(r2))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68400e4df9d48321814a03de748a2456