### PR TITLE
Add Python 3.11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Zipper - Action Adventure Platform game implemented in Kivy
 
 Currently only a very small sandbox environment is present, with some rudimentary movement / collision.  More is on the way.
 
-To test it out : 
+To test it out :
 
-- Install Python 2.7
-- Install Kivy 
+- Install Python 3.11
+- Install Kivy 2.2 or newer
 - Clone the repository
 - Run main.py
 

--- a/main.py
+++ b/main.py
@@ -369,7 +369,7 @@ class Player_Sprite(Image):
         len_to_collide = self.animlen  # Arbitrary number TODO - implement a better method to decide the len of travel
         if len_to_collide > 0:  # added to ensure 0 length handling, as it's instantiated as zero
             self.zipping = True
-            for index,coltick in enumerate(xrange(1, len_to_collide)):
+            for index,coltick in enumerate(range(1, len_to_collide)):
                 lastRect = Rect(self.pos[0]+(self.width*.42)+(sa_collider[0]*index), self.pos[1]+(self.height*.35)
                                 +(sa_collider[1]*index),(self.size[0]*.16), self.size[1]*.29)
                 #  In brief :

--- a/rect.py
+++ b/rect.py
@@ -74,6 +74,9 @@ class Rect(object):
     def __nonzero__(self):
         return bool(self.width and self.height)
 
+    # Python 3.x truthiness support
+    __bool__ = __nonzero__
+
     def __repr__(self):
         return 'Rect(xy=%.4g,%.4g; wh=%.4g,%.4g)'%(self.x, self.y,
             self.width, self.height)

--- a/tmx.py
+++ b/tmx.py
@@ -10,9 +10,11 @@ import struct
 from xml.etree import ElementTree
 from rect import Rect
 
+import base64
+import zlib
 import kivy
 
-kivy.require('1.8.0')
+kivy.require('2.2.0')
 
 from kivy.uix.image import Image
 from kivy.graphics import Rectangle, Color
@@ -114,8 +116,8 @@ class Tileset(object):
         id = self.firstgid
         th = self.tile_height + self.spacing
         tw = self.tile_width + self.spacing
-        for j in xrange(texture.height / th):
-            for i in xrange(texture.width / tw):
+        for j in range(texture.height // th):
+            for i in range(texture.width // tw):
                 x = (i * tw) + self.margin
                 # convert the y coordinate to OpenGL (0 at bottom of texture)
                 y = texture.height - ((j + 1) * th)
@@ -288,8 +290,9 @@ class Layer(object):
             raise ValueError('layer %s does not contain <data>' % layer.name)
 
         data = data.text.strip()
-        data = data.decode('base64').decode('zlib')
-        data = struct.unpack('<%di' % (len(data) / 4,), data)
+        data = base64.b64decode(data)
+        data = zlib.decompress(data)
+        data = struct.unpack('<%di' % (len(data) // 4,), data)
         assert len(data) == layer.width * layer.height, "data len (%d) != width (%d) x height (%d)" % (
         len(data), layer.width, layer.height)
         for i, gid in enumerate(data):


### PR DESCRIPTION
## Summary
- document that Python 3.11 and Kivy 2.2+ are required
- update Kivy requirement and data decoding in `tmx.py`
- replace `xrange` usage with `range`
- ensure integer divisions use `//`
- add `__bool__` alias in `rect.py`

## Testing
- `python3.11 -m py_compile main.py tmx.py rect.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a1ca81788321a9c7463cb4a1e517