### PR TITLE
Add packaging support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md LICENSE Zippy.kv zippy_screenshot.png
+recursive-include Maps *
+recursive-include Tiles *
+recursive-include animation *

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+"""Zipper game package."""

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,19 @@
+from kivy.core.window import Window
+from .main import ZippyApp, keys
+
+
+def on_key_down(window, keycode, *rest):
+    keys[keycode] = True
+
+
+def on_key_up(window, keycode, *rest):
+    keys[keycode] = False
+
+
+def main():
+    Window.bind(on_key_down=on_key_down, on_key_up=on_key_up)
+    ZippyApp().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zipper"
+version = "0.1.0"
+description = "Zipper - Action Adventure Platform game implemented in Kivy"
+authors = [{name = "Unknown"}]
+readme = "README.md"
+requires-python = ">=3.8"
+license = {file = "LICENSE"}
+dependencies = [
+    "kivy>=2.0.0"
+]
+
+[tool.setuptools]
+packages = ["zipper"]
+include-package-data = true
+
+[project.scripts]
+zipper = "zipper.__main__:main"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
## Summary
- package the repo with pyproject and setup.py
- expose a python entry point in `__main__.py`
- include non-code assets in wheel

## Testing
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `python -m zipper --help` *(fails: ModuleNotFoundError: No module named 'kivy')*

------
https://chatgpt.com/codex/tasks/task_e_6845a1eea80483218288e37a618015db