### PR TITLE
Refactor keyboard handling with InputManager

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,19 +1,12 @@
-from kivy.core.window import Window
-from .main import ZippyApp, keys
-
-
-def on_key_down(window, keycode, *rest):
-    keys[keycode] = True
-
-
-def on_key_up(window, keycode, *rest):
-    keys[keycode] = False
+from .main import ZippyApp
+# Import the input manager so that it binds to the Window on module load
+from .input_manager import input_manager  # noqa: F401
 
 
 def main():
-    Window.bind(on_key_down=on_key_down, on_key_up=on_key_up)
     ZippyApp().run()
 
 
 if __name__ == "__main__":
     main()
+

--- a/input_manager.py
+++ b/input_manager.py
@@ -1,0 +1,24 @@
+from collections import defaultdict
+from kivy.core.window import Window
+
+
+class InputManager:
+    """Simple keyboard input handler maintaining key states."""
+
+    def __init__(self):
+        self.keys = defaultdict(lambda: False)
+        Window.bind(on_key_down=self.on_key_down, on_key_up=self.on_key_up)
+
+    def on_key_down(self, window, keycode, *args):
+        self.keys[keycode] = True
+
+    def on_key_up(self, window, keycode, *args):
+        self.keys[keycode] = False
+
+    def is_pressed(self, keycode):
+        """Return True if the given keycode is currently pressed."""
+        return self.keys.get(keycode, False)
+
+
+# Global instance used throughout the project
+input_manager = InputManager()

--- a/main.py
+++ b/main.py
@@ -14,10 +14,9 @@ from kivy.uix.floatlayout import FloatLayout
 from kivy.properties import NumericProperty, BooleanProperty, ReferenceListProperty, ObjectProperty,StringProperty
 import tmx
 from rect import Rect
-from collections import defaultdict
 from math import atan2, degrees, pi
+from input_manager import input_manager
 
-keys = defaultdict(lambda: False)
 sys.setrecursionlimit(10000)
 
 class ZippyApp(App):
@@ -103,7 +102,7 @@ class ZippyGame(FloatLayout):
             self.zipmeter.gain_bar('MP')
             # if we were moving before, display a 'standing' image
             if self.sprite.resting and not self.sprite.zipping:
-                if not keys.get(Keyboard.keycodes['right']) and not keys.get(Keyboard.keycodes['left']):
+                if not input_manager.is_pressed(Keyboard.keycodes['right']) and not input_manager.is_pressed(Keyboard.keycodes['left']):
                     self.sprite.texture = self.sprite.mov_images['walk_1_left'] if self.sprite.prevdir == 'left' \
                         else self.sprite.mov_images['walk_1_right']
             # initialise the direction on x/y to zero
@@ -112,33 +111,33 @@ class ZippyGame(FloatLayout):
             self.sprite.last = Rect(self.sprite.pos[0]+(self.sprite.width*.42),self.sprite.pos[1]+(self.sprite.height*.35), (self.sprite.size[0]*.16),
                              self.sprite.size[1]*.29)
             # move left
-            if (keys.get(Keyboard.keycodes['left']) or keys.get(Keyboard.keycodes['a'])) and not keys.get(Keyboard.keycodes['right']):
+            if (input_manager.is_pressed(Keyboard.keycodes['left']) or input_manager.is_pressed(Keyboard.keycodes['a'])) and not input_manager.is_pressed(Keyboard.keycodes['right']):
                 self.sprite.dx -= 5 * params.scale
                 self.sprite.moving_left = True
                 self.sprite.moving_right = False
                 self.sprite.texture = self.sprite.mov_images['walk_2_left'] if not self.sprite.jumping else self.sprite.mov_images['jump_l']
                 self.sprite.prevdir = 'left'
             # move right
-            elif (keys.get(Keyboard.keycodes['right']) or keys.get(Keyboard.keycodes['d'])) and not keys.get(Keyboard.keycodes['left']):
+            elif (input_manager.is_pressed(Keyboard.keycodes['right']) or input_manager.is_pressed(Keyboard.keycodes['d'])) and not input_manager.is_pressed(Keyboard.keycodes['left']):
                 self.sprite.dx += 5 * params.scale
                 self.sprite.moving_right = True
                 self.sprite.moving_left = False
                 self.sprite.texture = self.sprite.mov_images['walk_2_right'] if not self.sprite.jumping else self.sprite.mov_images['jump_r']
                 self.sprite.prevdir = 'right'
             # if both keys pressed, do nothing
-            elif (keys.get(Keyboard.keycodes['right']) or keys.get(Keyboard.keycodes['d'])) and \
-                    (keys.get(Keyboard.keycodes['left']) or keys.get(Keyboard.keycodes['a'])):
+            elif (input_manager.is_pressed(Keyboard.keycodes['right']) or input_manager.is_pressed(Keyboard.keycodes['d'])) and \
+                    (input_manager.is_pressed(Keyboard.keycodes['left']) or input_manager.is_pressed(Keyboard.keycodes['a'])):
                 self.sprite.moving_left, self.sprite.moving_right = False,False
             # rudimentary gravity
             if not self.sprite.jumping:
                 self.sprite.dy -= 4 * params.scale
             # if we were jumping, but have released the key
             if self.sprite.jumping:
-                if not keys.get(Keyboard.keycodes['spacebar']):
+                if not input_manager.is_pressed(Keyboard.keycodes['spacebar']):
                     self.sprite.jumping = False
                     self.sprite.movyval = 0
             # initiate attack animation
-            if keys.get(Keyboard.keycodes['x']):
+            if input_manager.is_pressed(Keyboard.keycodes['x']):
                 if self.sprite.atkcounter > 20:
                     self.sprite.atkcounter = 0
                 else:
@@ -146,12 +145,12 @@ class ZippyGame(FloatLayout):
                         else self.sprite.atk_images['attack2_r']
                     self.sprite.atkcounter += 1
             # initiate a jump
-            if keys.get(Keyboard.keycodes['spacebar']) and self.sprite.resting:
+            if input_manager.is_pressed(Keyboard.keycodes['spacebar']) and self.sprite.resting:
                 self.sprite.jumping = True
                 self.sprite.resting = False
                 self.sprite.dy = 5 * params.scale
             # there's a peak to every jump, after which, no more vertical movement
-            elif keys.get(Keyboard.keycodes['spacebar']) and self.sprite.jumping:
+            elif input_manager.is_pressed(Keyboard.keycodes['spacebar']) and self.sprite.jumping:
                 if self.sprite.movyval > 20:
                     self.sprite.jumping = False
                     self.sprite.movyval = 0
@@ -441,11 +440,5 @@ class Player_Sprite(Image):
 params = params()
 
 if __name__ == '__main__':
-    def on_key_down(window, keycode, *rest):
-        keys[keycode] = True
-    def on_key_up(window, keycode, *rest):
-        keys[keycode] = False
-
-    Window.bind(on_key_down=on_key_down, on_key_up=on_key_up)
     ZippyApp().run()
 


### PR DESCRIPTION
## Summary
- implement `InputManager` for binding to keyboard events and tracking key states
- use the new manager within `main.py` and remove global key dict
- simplify `__main__.py` to rely on `InputManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845bc4a7bd083218d0210122aa91f64